### PR TITLE
R::set can now modify final fields on old java versions

### DIFF
--- a/src/main/java/me/mrnavastar/r/R.java
+++ b/src/main/java/me/mrnavastar/r/R.java
@@ -6,6 +6,17 @@ import java.util.Objects;
 
 public class R {
 
+    private static boolean oldJavaCompat = false;
+    static {
+        try {
+            // Check if the Field class has a "modifiers" field
+            Field.class.getDeclaredField("modifiers");
+            oldJavaCompat = true;
+        } catch (NoSuchFieldException e) {
+        }
+    }
+
+
     private final Object instance;
     private final Class<?> clazz;
 
@@ -89,8 +100,10 @@ public class R {
     public R set(String name, Object value) {
         try {
             Field toSet = findField(name, clazz);
-            Field modifiersField = findField("modifiers", toSet.getClass());
-            modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+            if (oldJavaCompat) {
+                Field modifiersField = findField("modifiers", toSet.getClass());
+                modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+            }
             toSet.set(instance, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);

--- a/src/main/java/me/mrnavastar/r/R.java
+++ b/src/main/java/me/mrnavastar/r/R.java
@@ -89,9 +89,9 @@ public class R {
     public R set(String name, Object value) {
         try {
             Field toSet = findField(name, clazz);
-            Field modifiersField = findField("modifiers", Field.class);
+            Field modifiersField = findField("modifiers", toSet.getClass());
             modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-            findField(name, clazz).set(instance, value);
+            toSet.set(instance, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/me/mrnavastar/r/R.java
+++ b/src/main/java/me/mrnavastar/r/R.java
@@ -88,6 +88,9 @@ public class R {
      */
     public R set(String name, Object value) {
         try {
+            Field toSet = findField(name, clazz);
+            Field modifiersField = findField("modifiers", Field.class);
+            modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
             findField(name, clazz).set(instance, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);

--- a/src/main/java/me/mrnavastar/r/R.java
+++ b/src/main/java/me/mrnavastar/r/R.java
@@ -9,13 +9,10 @@ public class R {
     private static boolean oldJavaCompat = false;
     static {
         try {
-            // Check if the Field class has a "modifiers" field
             Field.class.getDeclaredField("modifiers");
             oldJavaCompat = true;
-        } catch (NoSuchFieldException e) {
-        }
+        } catch (NoSuchFieldException ignore) {}
     }
-
 
     private final Object instance;
     private final Class<?> clazz;


### PR DESCRIPTION
R docstring says "can be private, final, or static", but it never actually strips the final modifier on old versions of java to be able to set them

Sorry, I thought you meant I had made this here and wasn't sure if I intended to make it here or in mine. Sorry about that :sweat_smile: 